### PR TITLE
Draft: Initial Helm Chart setup for Kubernetes deployment (#30)

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: floto
+description: Helm chart for Floto (web + celery), with optional MariaDB/Redis
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+dependencies:
+  - name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: X.Y.Z           # pin a tested version
+    condition: mariadb.enabled
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: X.Y.Z           # pin a tested version
+    condition: redis.enabled

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,67 @@
+image:
+  repository: floto-dev
+  tag: latest
+  pullPolicy: IfNotPresent
+
+floto:
+  port: 8000                 # maps your ${FLOTO_PORT}
+  replicas: 1
+
+env:                          # non-sensitive env (ConfigMap material)
+  - name: DJANGO_SETTINGS_MODULE
+    value: floto.settings
+
+secrets:                      # sensitive env (Secret material)
+  DB_PASSWORD: ""
+  DB_USER: ""
+  DB_NAME: ""
+  DB_ROOT_PASSWORD: ""
+
+persistence:
+  media:
+    enabled: true
+    size: 5Gi
+  config:
+    enabled: true
+    size: 1Gi
+  static:
+    enabled: true
+    size: 1Gi
+
+mariadb:
+  enabled: true               # flip to false to use external DB
+  auth:
+    rootPassword: ""
+    username: ""
+    password: ""
+    database: ""
+  primary:
+    persistence:
+      enabled: true
+      size: 5Gi
+
+redis:
+  enabled: true               # flip to false to use external Redis
+  architecture: standalone
+  master:
+    persistence:
+      enabled: true
+      size: 1Gi
+
+externalDatabase:
+  enabled: false
+  host: ""
+  port: 3306
+  database: ""
+  username: ""
+  passwordSecretRef:
+    name: ""                  # k8s Secret name
+    key: ""                   # key inside that Secret
+
+externalRedis:
+  enabled: false
+  host: ""
+  port: 6379
+  passwordSecretRef:
+    name: ""
+    key: ""


### PR DESCRIPTION
This is a draft PR for Issue #30: adding Helm Chart support for Kubernetes deployment.

- Added initial Chart.yaml and values.yaml
- Performed a first analysis of the Docker Compose setup (not included here)
- This PR is intended to start discussion and receive feedback on next steps

Next steps pending feedback:
- Verify correct values for deployment and services
- Add templates for Deployment, Service, and ConfigMap
- Incorporate any translation or configuration specifics as suggested by maintainers

References: #30
